### PR TITLE
Fix URL to use only http

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Logo adapted from "[Death Star](https://thenounproject.com/term/death-star/19100
 
 ## Author
 
-Ritter Insurance Marketing https://rimdev.io
+Ritter Insurance Marketing http://rimdev.io
 
 ## License
 


### PR DESCRIPTION
Currently rimdev.io only works with http (it's only a blog anyway ;) )