### PR TITLE
Add fetch polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "md5": "^2.1.0",
     "randgen": "^0.1.0",
     "request-promise": "^3.0.0",
+    "whatwg-fetch": "^1.0.0",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,10 @@
 const path = require('path');
 
 module.exports = {
-  entry: './src/client/app.js',
+  entry: [
+    'whatwg-fetch',
+    './src/client/app.js'
+  ],
   output: {
     path: './public/lib',
     filename: 'bundle.js'


### PR DESCRIPTION
A `fetch` polyfill is currently needed for Microsoft Edge.

Microsoft Edge will support `fetch` as part of the Windows 10 Anniversary Update. https://blogs.windows.com/msedgedev/2016/05/24/fetch-and-xhr-limitations/