### PR TITLE
Do not show error for no .env

### DIFF
--- a/src/server/configuration-provider.js
+++ b/src/server/configuration-provider.js
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 
 export default class ConfigurationProvider {
   constructor() {
-    dotenv.config();
+    dotenv.config({ silent: true });
   }
 
   getConfiguration() {


### PR DESCRIPTION
Do not show an error in the console when no `.env` is present.