### PR TITLE
Remove extract-text-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "d3-svg-legend": "^1.12.0",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
-    "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "font-awesome": "^4.6.3",
     "md5": "^2.1.0",

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <title>Org Chart</title>
-    <link rel="stylesheet" href="lib/bundle.css" />
   </head>
 
   <body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
   entry: [
@@ -24,16 +23,14 @@ module.exports = {
       },
       {
         test: /\.css$/,
-        loader: ExtractTextPlugin.extract('style-loader', 'css-loader')
+        loader: 'style-loader!css-loader'
       },
 
+      // These loaders adapted from
       // https://github.com/gowravshekar/font-awesome-webpack/tree/48a9151238e6ebe382301512a48183a7ae057f62#usage
-      { test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "url-loader?limit=10000&mimetype=application/font-woff" },
-      { test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "file-loader" }
+      { test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'url-loader?name=lib/[name]&limit=10000&mimetype=application/font-woff' },
+      { test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'file-loader?name=[hash].[ext]' }
     ]
   },
-  plugins: [
-    new ExtractTextPlugin('bundle.css')
-  ],
   devTool: 'source-map'
 };


### PR DESCRIPTION
Remove `extract-text-webpack-plugin` in attempt to fix issue in Azure Web Apps deployment.