### PR TITLE
Add Office365GetPersonaPhotoImageRetriever, allow configurable image retriever

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ CLIENT_ID=the_client_id_value
 CLIENT_SECRET=the_client_secret_value
 ```
 
+Optionally, specify the `IMAGE_RETRIEVER` in `.env` as well *(defaults to `GravatarImageRetriever`)*:
+
+```
+IMAGE_RETRIEVER=Office365GetPersonaPhotoImageRetriever
+```
+
 - Install, build, and start:
 
 ```sh

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -1,14 +1,13 @@
 import Directory from './directory';
 import ForceDirectedGraphRenderer from './force-directed-graph-renderer';
-import GravatarImageRetriever from './gravatar-image-retriever';
+import Office365GetPersonaPhotoImageRetriever from './office365-get-persona-photo-image-retriever';
 
 const containerElement = document.getElementById('js-org-svg-container');
 const directoryUrl = 'directory';
 const filterFunction = x => x.department;
 
 const directory = new Directory();
-const picturePxSize = 150;
-const imageRetriever = new GravatarImageRetriever(picturePxSize);
+const imageRetriever = new Office365GetPersonaPhotoImageRetriever();
 const renderer = new ForceDirectedGraphRenderer(
   containerElement,
   imageRetriever);

--- a/src/client/app.js
+++ b/src/client/app.js
@@ -1,4 +1,5 @@
 import Directory from './directory';
+import GravatarImageRetriever from './gravatar-image-retriever';
 import ForceDirectedGraphRenderer from './force-directed-graph-renderer';
 import Office365GetPersonaPhotoImageRetriever from './office365-get-persona-photo-image-retriever';
 
@@ -7,7 +8,10 @@ const directoryUrl = 'directory';
 const filterFunction = x => x.department;
 
 const directory = new Directory();
-const imageRetriever = new Office365GetPersonaPhotoImageRetriever();
+const imageRetriever = process.env.IMAGE_RETRIEVER === 'Office365GetPersonaPhotoImageRetriever'
+  ? new Office365GetPersonaPhotoImageRetriever()
+  : new GravatarImageRetriever(150); // eslint-disable-line no-magic-numbers
+
 const renderer = new ForceDirectedGraphRenderer(
   containerElement,
   imageRetriever);

--- a/src/client/office365-get-persona-photo-image-retriever.js
+++ b/src/client/office365-get-persona-photo-image-retriever.js
@@ -1,0 +1,14 @@
+// This relies on the user's browser being logged in to an Office365 account
+// that has the appropriate permissions.
+//
+// This is not an ideal way to do this.
+export default class Office365GetPersonaPhotoImageRetriever {
+  getImageUrl(email) {
+    // Photo sizes reference:
+    // https://blogs.msdn.microsoft.com/briangre/2014/03/11/options-for-sharepoint-user-profile-properties-and-photos/
+    // (assuming all those sizes work here)
+    return 'https://outlook.office365.com/owa/service.svc/s/GetPersonaPhoto'
+      + `?email=${email}`
+      + '&size=HR240x240';
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,8 @@
 const path = require('path');
+const dotenv = require('dotenv');
+const webpack = require('webpack');
+
+dotenv.config({ silent: true });
 
 module.exports = {
   entry: [
@@ -23,5 +27,10 @@ module.exports = {
       }
     ]
   },
+  plugins: [
+    new webpack.EnvironmentPlugin([
+      "IMAGE_RETRIEVER"
+    ])
+  ],
   devTool: 'source-map'
 };


### PR DESCRIPTION
`Office365GetPersonaPhotoImageRetriever` is not an ideal solution as it expects the user's browser to be logged in and have the appropriate permissions.