### PR TITLE
Use same-origin credentials when fetching directory info

### DIFF
--- a/src/client/directory.js
+++ b/src/client/directory.js
@@ -1,6 +1,8 @@
 export default class Directory {
   getUsers(directoryUrl, filterFunction) {
-    return fetch(directoryUrl)
+    return fetch(directoryUrl, {
+      credentials: 'same-origin'
+    })
       .then(res => res.json())
       .then(users => {
         if (filterFunction) {


### PR DESCRIPTION
This is in support of securing this application using https://azure.microsoft.com/en-us/documentation/articles/app-service-authentication-overview/.