### PR TITLE
[WIP] Suppress node-uuid warning from test output

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "ava": {
     "require": [
       "babel-core/register",
-      "./test/helpers/setup-browser-env.js"
+      "./test/helpers/setup-browser-env.js",
+      "./test/helpers/suppress-node-uuid-warning.js"
     ]
   },
   "nyc": {

--- a/test/helpers/suppress-node-uuid-warning.js
+++ b/test/helpers/suppress-node-uuid-warning.js
@@ -1,0 +1,15 @@
+/* eslint-disable */
+
+window.crypto = {
+  getRandomValues: function(typedArray) {
+    for (let i = 0; i < typedArray.length; i++) {
+      typedArray[i] =
+
+      // http://stackoverflow.com/a/2117523
+      'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+        return v.toString(16);
+      });
+    }
+  }
+};


### PR DESCRIPTION
Suppress this warning from `npm test` run:

```
[SECURITY] node-uuid: crypto not usable, falling back to insecure Math.random()
```
