### PR TITLE
Improve webpack performance

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const dotenv = require('dotenv');
+const path = require('path');
 const webpack = require('webpack');
 
 dotenv.config({ silent: true });
@@ -17,6 +18,9 @@ module.exports = {
       {
         test: /\.js$/,
         loader: 'babel-loader',
+        include: [
+          path.resolve(process.cwd(), 'src')
+        ],
         query: {
           presets: ['es2015']
         }


### PR DESCRIPTION
The `include` was removed in #35 due to an issue with Azure Web Apps. Let's try it again, but using `process.cwd()` instead of `__dirname`.

## master

```
λ webpack -d
[BABEL] Note: The code generator has deoptimised the styling of "C:/Users/ken.dale/Documents/Projects/star-orgs/node_modules/d3/d3.js" as it exceeds the max of "100KB".
Hash: 55227dd12c2939f0b3e1
Version: webpack 1.13.1
Time: 6927ms
        Asset    Size  Chunks             Chunk Names
    bundle.js  312 kB       0  [emitted]  main
bundle.js.map  835 kB       0  [emitted]  main
   [0] multi main 40 bytes {0} [built]
    + 16 hidden modules

WARNING in IMAGE_RETRIEVER environment variable is undefined.
```

## speed-up-webpack

```
λ webpack -d
Hash: 0a11decf12f470663c4b
Version: webpack 1.13.1
Time: 2027ms
        Asset    Size  Chunks             Chunk Names
    bundle.js  413 kB       0  [emitted]  main
bundle.js.map  478 kB       0  [emitted]  main
   [0] multi main 40 bytes {0} [built]
    + 16 hidden modules

WARNING in IMAGE_RETRIEVER environment variable is undefined.
```