### PR TITLE
Hide broken images on chart

### DIFF
--- a/src/client/force-directed-graph-renderer.js
+++ b/src/client/force-directed-graph-renderer.js
@@ -89,6 +89,7 @@ export default class ForceDirectedGraphRenderer {
     node.append('image')
       .attr('class', 'circle-image')
       .attr('xlink:href', d => this.imageRetriever.getImageUrl(d.email))
+      .attr('onerror', 'this.style.display = "none"') // Adapted from http://stackoverflow.com/a/3236110
       .attr('x', d => radius * d.radiusMultiplier / 2 + circleImageStrokeBorderPx)
       .attr('y', d => radius * d.radiusMultiplier / 2 + circleImageStrokeBorderPx)
       .attr('width', d => radius * 2 * d.radiusMultiplier - circleImageStrokeBorderPx * 2)


### PR DESCRIPTION
Hide broken images to prevent covering initials with broken images.