### PR TITLE
Remove blank groups to avoid potential error

### DIFF
--- a/src/client/force-directed-graph-renderer.js
+++ b/src/client/force-directed-graph-renderer.js
@@ -161,7 +161,7 @@ export default class ForceDirectedGraphRenderer {
         group: groupBy(d),
         color: color(groupBy(d))
       };
-    })));
+    }))).filter(x => x.group);
 
     const uniqueGroupsWithColors = [];
 


### PR DESCRIPTION
To avoid calling `localeCompare` when not possible (may only be applicable in subsequent PR).